### PR TITLE
tox: freeze setuptools<82

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
   requests<2.32.0  # https://github.com/ansible-community/molecule-plugins/pull/257
   pytest<8.0.0  # see https://github.com/pytest-dev/pytest/issues/11904
   pytest-testinfra
+  setuptools<82 # https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals, pkg_resources used by ansible.builtin.pip
 pass_env =
   HOME
   SSH_AUTH_SOCK


### PR DESCRIPTION
**why**
see https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals This role relie on brianshumate.consul role, that uses `pkg_resources` under the hood. The deprecation breaks the molecule tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts test dependencies to avoid upstream `setuptools` deprecations; main code/runtime behavior is unchanged. The primary risk is masking compatibility issues with newer `setuptools` until the underlying `pkg_resources` usage is removed.
> 
> **Overview**
> Pins `setuptools` to `<82` in `tox.ini` for the `molecule` test environment to avoid failures from the upstream removal of `pkg_resources` (used indirectly during `ansible.builtin.pip`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b67ed748fbb9460e53f2742ba6d81ef22705605b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->