### PR TITLE
Add apt retries for molecule tests on debian<=12

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: Prepare
+  hosts: all
+  become: yes
+
+  tasks:
+  - name: Set apt retries for debian <=12
+    ansible.builtin.copy:
+      dest: /etc/apt/apt.conf.d/99-retries.conf
+      content: |
+        Acquire::Retries "5";
+      owner: root
+      group: root
+      mode: "0644"
+    become: true
+    when:
+      - ansible_distribution == "Debian"
+      - ansible_distribution_major_version | int <= 12


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk test-environment change that only affects Molecule provisioning on Debian containers; it may mask transient apt issues but doesn’t impact role/runtime behavior.
> 
> **Overview**
> Adds a Molecule `prepare.yml` playbook that writes `/etc/apt/apt.conf.d/99-retries.conf` to set `Acquire::Retries "5"` on Debian hosts with major version <= 12, improving resiliency of apt operations during CI runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b763a8a424c49798272d3166b7ae6924d829c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->