### PR TITLE
fix: enables tlsv1.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,9 @@ coturn_web_admin_port: 9090
 
 # TLS related parameters
 coturn_tls_enabled: false
-coturn_tls_v1_3_only: true
+# Disable the obsolete TLS 1.0/1.1 on the TURNS listener but keep TLS 1.2 (and 1.3).
+# TURN clients, turnutils_uclient and browsers negotiate TLS 1.2
+coturn_tls_min_v1_2: true
 coturn_dtls_enabled: false
 
 coturn_tls_listening_port: 5349

--- a/templates/turnserver.conf.j2
+++ b/templates/turnserver.conf.j2
@@ -829,10 +829,10 @@ web-admin-port={{ coturn_web_admin_port }}
 
 # Do not allow an TLS/DTLS version of protocol
 #
-{% if coturn_tls_v1_3_only %}
+{% if coturn_tls_min_v1_2 %}
 no-tlsv1
 no-tlsv1_1
-no-tlsv1_2
+#no-tlsv1_2
 {% else %}
 #no-tlsv1
 #no-tlsv1_1


### PR DESCRIPTION
**why**
This was disabled with no explanation long time ago. With the good set of cipher list (that we already have), it remains secure.

The goal of this is to easily test coturn via turnutils on TLS-TCP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live TURNS protocol versions when TLS is enabled; deployments must migrate the renamed variable, though obsolete TLS 1.0/1.1 remain disabled with the existing cipher list.
> 
> **Overview**
> **Replaces the TLS “1.3 only” knob with a clearer minimum-TLS-1.2 default** so coturn’s TURNS listener blocks TLS 1.0/1.1 but allows TLS 1.2 (and 1.3).
> 
> The Ansible default renames `coturn_tls_v1_3_only` to `coturn_tls_min_v1_2` (still default `true`) and updates `turnserver.conf.j2` so the conditional emits `no-tlsv1` / `no-tlsv1_1` while **leaving `no-tlsv1_2` commented out**—previously TLS 1.2 was explicitly disabled. That aligns TURNS with typical TURN clients, `turnutils_uclient`, and browsers that negotiate TLS 1.2, while keeping the existing strong cipher list.
> 
> **Breaking rename:** any playbook or inventory still setting `coturn_tls_v1_3_only` must switch to `coturn_tls_min_v1_2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152152b9c8202d10797f402b31be0709cc38a453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->