### PR TITLE
Fix wazo.consul dependency in molecule

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: molecule_coturn
+  hosts: molecule_coturn:!molecule-coturn-stun-client
   become: yes
 
   vars:
@@ -19,59 +19,6 @@
     coturn_alternative_listening_port: 54321
 
     consul_enabled: true
-    consul_node_role: bootstrap
-    consul_group_name: all
-
-  pre_tasks:
-    - name: Install curl for tests purpose
-      ansible.builtin.apt:
-        name: curl
-        update_cache: true
-      tags: molecule-idempotence-notest
 
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
-
-- name: Setting up a STUN client
-  hosts: molecule-coturn-stun-client
-  become: yes
-
-  tasks:
-    - name: Create directory
-      ansible.builtin.file:
-        path: /opt/stun
-        state: directory
-        owner: root
-        group: root
-        mode: '0770'
-
-    - name: Install NodeJS stun library
-      community.general.npm:
-        name: stun
-        path: /opt/stun
-
-    - name: Write a NodeJS client
-      ansible.builtin.copy:
-        content: |
-          const stun = require('stun');
-
-          const args = process.argv;
-          const ip = args[2];
-          const port = args[3]
-
-          if (!ip || !port) {
-              throw "Usage: node stun_client.js <ip> <port>"
-          }
-          stun.request(`${ip}:${port}`, (err, res) => {
-              if (err) {
-                  console.log(`Error fetching my IP from the STUN server at ${ip}:${port}`);
-                  console.error(err);
-              } else {
-                  const {
-                      address
-                  } = res.getXorAddress();
-                  console.log('My IP is ', address);
-              }
-          });
-        dest: /opt/stun/client.js
-        mode: "0555"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,6 +1,6 @@
 ---
 - name: Prepare
-  hosts: all
+  hosts: all:!molecule-coturn-stun-client
   become: yes
 
   tasks:
@@ -16,3 +16,74 @@
     when:
       - ansible_distribution == "Debian"
       - ansible_distribution_major_version | int <= 12
+
+  - name: Install curl for tests purpose
+    ansible.builtin.apt:
+      name: curl
+      update_cache: true
+
+  # wazo.consul falls back to dnsmasq when systemd-resolved is not running
+  # (as in this container). Its dnsmasq config uses `no-resolv` with upstream
+  # servers taken only from consul_dnsmasq_servers (default: []), then repoints
+  # /etc/resolv.conf at dnsmasq. With no upstream, all non-consul name
+  # resolution breaks. Capture the container's current nameservers (Docker's
+  # embedded DNS, 127.0.0.11) and hand them to dnsmasq as upstreams.
+  - name: Read existing DNS nameservers before consul rewrites resolv.conf
+    ansible.builtin.shell: |
+      set -o pipefail
+      awk '/^nameserver/ { print $2 }' /etc/resolv.conf
+    args:
+      executable: /bin/bash
+    register: existing_nameservers
+    changed_when: false
+
+  - name: Include consul role
+    ansible.builtin.include_role:
+      name: wazo.consul
+    vars:
+      consul_node_role: bootstrap
+      consul_dnsmasq_servers: "{{ existing_nameservers.stdout_lines }}"
+
+- name: Setting up a STUN client
+  hosts: molecule-coturn-stun-client
+  become: yes
+
+  tasks:
+    - name: Create directory
+      ansible.builtin.file:
+        path: /opt/stun
+        state: directory
+        owner: root
+        group: root
+        mode: '0770'
+
+    - name: Install NodeJS stun library
+      community.general.npm:
+        name: stun
+        path: /opt/stun
+
+    - name: Write a NodeJS client
+      ansible.builtin.copy:
+        content: |
+          const stun = require('stun');
+
+          const args = process.argv;
+          const ip = args[2];
+          const port = args[3]
+
+          if (!ip || !port) {
+              throw "Usage: node stun_client.js <ip> <port>"
+          }
+          stun.request(`${ip}:${port}`, (err, res) => {
+              if (err) {
+                  console.log(`Error fetching my IP from the STUN server at ${ip}:${port}`);
+                  console.error(err);
+              } else {
+                  const {
+                      address
+                  } = res.getXorAddress();
+                  console.log('My IP is ', address);
+              }
+          });
+        dest: /opt/stun/client.js
+        mode: "0555"

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -3,6 +3,10 @@
   scm: git
   name: wazo.metadata
 
+- src: https://github.com/wazo-platform/ansible-role-consul.git
+  scm: git
+  name: wazo.consul
+
 - src: https://github.com/wazo-platform/ansible-role-consul-service.git
   scm: git
   name: wazo.consul-service

--- a/molecule/default/tests/test_coturn.py
+++ b/molecule/default/tests/test_coturn.py
@@ -22,8 +22,8 @@ def test_packages(host, name):
 @pytest.mark.parametrize(
     "path",
     [
-        "/etc/consul/consul.d/coturn-metrics.service.json",
-        "/etc/consul/consul.d/coturn-ui.service.json",
+        "/etc/consul.d/coturn-metrics.service.json",
+        "/etc/consul.d/coturn-ui.service.json",
         "/etc/default/coturn",
         "/etc/logrotate.d/rsyslog",
         "/etc/turnserver.conf",


### PR DESCRIPTION
Since we updated `wazo.consul-service` dependency from `brianshumate.consul` to `wazo.consul`, we need to fix this repo molecule tests.

:warning: Some tasks were relocated from converge to prepare playbook as they make more sense there. They setup a turn client to run tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Molecule playbooks, role requirements, and test assertions; production Ansible role behavior is untouched.
> 
> **Overview**
> Aligns Molecule with the **`wazo.consul-service`** switch from **`brianshumate.consul`** to **`wazo.consul`**: **`requirements.yml`** now pulls **`wazo.consul`**, and **`prepare.yml`** bootstraps Consul (bootstrap node role) while capturing the container’s existing **`resolv.conf`** nameservers and passing them as **`consul_dnsmasq_servers`** so dnsmasq still has upstream DNS after Consul repoints resolution.
> 
> **`converge.yml`** is narrowed to coturn hosts only (STUN client excluded) and no longer installs curl, runs Consul, or provisions the Node STUN client—those steps live in **`prepare.yml`** alongside the existing apt-retry task. **`test_coturn.py`** expects Consul service definitions under **`/etc/consul.d/`** instead of **`/etc/consul/consul.d/`**, matching the new role layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff37da97f61779b6b9a9511d0cafde400ec0bcd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->